### PR TITLE
i496: add missing synchronization in method acceptRun(). Also,

### DIFF
--- a/src/edu/csus/ecs/pc2/core/model/InternalContest.java
+++ b/src/edu/csus/ecs/pc2/core/model/InternalContest.java
@@ -840,8 +840,12 @@ public class InternalContest implements IInternalContest {
         //construct an AvailableAJRun from the specified input run
         AvailableAJRun availableAJRun = new AvailableAJRun(run.getElementId(), run.getElapsedMS(), run.getProblemId());
         
-        //put the availableAJRun in the list of runs available for auto-judging
-        availableAJRunList.add(availableAJRun);
+        //ensure that we don't mess with the available-runs list while some other thread is doing so (for example, running inside method dispatchRunsToAutoJudges())
+        synchronized (ajLock) {
+            
+            //put the availableAJRun in the list of runs available for auto-judging
+            availableAJRunList.add(availableAJRun);
+        }
     }
     
     /**
@@ -863,6 +867,8 @@ public class InternalContest implements IInternalContest {
                     
                     AvailableAJ chosenJudge = null;
                     AvailableAJRun chosenRun = null;
+                    //a list to keep track of runs on the "available AJ runs" list which actually get assigned to an AJ
+                    // (see comments below, where runs get added to this list)
                     AvailableAJRunList assignedRunsList = new AvailableAJRunList();
                     
                     //check each run which is awaiting an AJ


### PR DESCRIPTION
updated comments to clarify data structure usage.

### Description of what the PR does
Corrects a synchronization issue. 

### Issue which the PR fixes
This is a _partial_ fix for #496.

### Environment in which the PR was developed (OS,IDE, Java version, etc.)
Windows 10.1, Eclipse 2020.12

### Precise steps for _testing_ the PR (i.e., how to demonstrate that it works correctly)
No steps available since this entire branch is still a work-in-progress.
